### PR TITLE
BUG: Fixing itkBoneMorphometryFeaturesImageFilter implementation

### DIFF
--- a/include/itkBoneMorphometryFeaturesImageFilter.hxx
+++ b/include/itkBoneMorphometryFeaturesImageFilter.hxx
@@ -123,6 +123,12 @@ BoneMorphometryFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
         // Iteration over the all neighborhood region
         for(NeighborIndexType nb = 0; nb<inputNIt.Size(); ++nb)
         {
+            tempOffset = inputNIt.GetOffset(nb);
+            if( !this->IsInsideNeighborhood(tempOffset) )
+            {
+              continue;
+            }
+
             if( maskPointer && maskPointer->GetPixel( inputNIt.GetIndex(nb) ) == 0 )
             {
               continue;
@@ -130,7 +136,6 @@ BoneMorphometryFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 
             ++numVoxels;
             inputNIt.GetPixel(nb);
-            tempOffset = inputNIt.GetOffset(nb);
             if( inputNIt.GetPixel(tempOffset) >= m_Threshold )
             {
               ++numBoneVoxels;


### PR DESCRIPTION
Solving a bug due to the accession of unexisting voxels
This bug was only appearing on windows machines