### PR TITLE
COMP: Fix '>=' signed/unsigned mismatch warning.

### DIFF
--- a/include/itkBoneMorphometryFeaturesImageFilter.hxx
+++ b/include/itkBoneMorphometryFeaturesImageFilter.hxx
@@ -200,7 +200,7 @@ BoneMorphometryFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
   bool insideMask = true;
   for (unsigned int i = 0; i < this->m_NeighborhoodRadius.Dimension; ++i)
   {
-      if (imageIndex[i] < 0 || imageIndex[i] >= maskSize[i])
+      if (imageIndex[i] < 0 || imageIndex[i] >= static_cast< long >( maskSize[i] ))
       {
           insideMask = false;
           break;


### PR DESCRIPTION
Fix '>=' signed/unsigned mismatch warning.

Addresses the corresponding warning raised by CDash when adding this
module as a remote to ITK in:
http://review.source.kitware.com/#/c/23429/