### PR TITLE
STYLE: Update to C++11 syntax.

### DIFF
--- a/include/itkBoneMorphometryFeaturesFilter.h
+++ b/include/itkBoneMorphometryFeaturesFilter.h
@@ -60,11 +60,11 @@ public ImageToImageFilter< TInputImage, TInputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(BoneMorphometryFeaturesFilter);
 
-  /** Standard Self typedef */
-  typedef BoneMorphometryFeaturesFilter                   Self;
-  typedef ImageToImageFilter< TInputImage, TInputImage >  Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard Self type alias. */
+  using Self = BoneMorphometryFeaturesFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TInputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -72,24 +72,24 @@ public:
   /** Runtime information support. */
   itkTypeMacro(BoneMorphometryFeaturesFilter, ImageToImageFilter);
 
-  /** Image related typedefs. */
-  typedef typename TInputImage::Pointer    InputImagePointer;
-  typedef typename TInputImage::RegionType RegionType;
-  typedef typename TInputImage::SizeType   SizeType;
-  typedef typename TInputImage::IndexType  IndexType;
-  typedef typename TInputImage::PixelType  PixelType;
+  /** Image related type alias. */
+  using InputImagePointer = typename TInputImage::Pointer;
+  using RegionType = typename TInputImage::RegionType;
+  using SizeType = typename TInputImage::SizeType;
+  using IndexType = typename TInputImage::IndexType;
+  using PixelType = typename TInputImage::PixelType;
 
-  /** Mask related typedefs. */
-  typedef typename TMaskImage::Pointer    MaskImagePointer;
+  /** Mask related type alias. */
+  using MaskImagePointer = typename TMaskImage::Pointer;
 
-  /** NeighborhoodIterator typedef */
-  typedef ConstantBoundaryCondition< TInputImage >                           BoundaryConditionType;
-  typedef ConstNeighborhoodIterator< TInputImage, BoundaryConditionType >    NeighborhoodIteratorType;
-  typedef typename NeighborhoodIteratorType::RadiusType                      NeighborhoodRadiusType;
-  typedef typename NeighborhoodIteratorType::OffsetType                      NeighborhoodOffsetType;
+  /** NeighborhoodIterator type alias */
+  using BoundaryConditionType = ConstantBoundaryCondition< TInputImage >;
+  using NeighborhoodIteratorType = ConstNeighborhoodIterator< TInputImage, BoundaryConditionType >;
+  using NeighborhoodRadiusType = typename NeighborhoodIteratorType::RadiusType;
+  using NeighborhoodOffsetType = typename NeighborhoodIteratorType::OffsetType;
 
   /** Type to use for computations. */
-  typedef typename NumericTraits< PixelType >::RealType RealType;
+  using RealType = typename NumericTraits< PixelType >::RealType;
 
   /** Methods to set/get the mask image */
   itkSetInputMacro(MaskImage, TMaskImage);
@@ -100,8 +100,7 @@ public:
   itkGetMacro(Threshold, RealType);
 
   /** Methods to get the mask different outputs */
-
-  typedef SimpleDataObjectDecorator< RealType > RealTypeDecoratedType;
+  using RealTypeDecoratedType = SimpleDataObjectDecorator< RealType >;
 
   RealType GetBVTV() { return m_Pp; }
   RealTypeDecoratedType * GetBVTVOutput()
@@ -153,25 +152,23 @@ public:
 
 protected:
   BoneMorphometryFeaturesFilter();
-  virtual ~BoneMorphometryFeaturesFilter() {}
+  ~BoneMorphometryFeaturesFilter() override {}
 
 
   /** Pass the input through unmodified. Do this by Grafting in the
-  *  AllocateOutputs method.
-  */
-  void AllocateOutputs() ITK_OVERRIDE;
+  * AllocateOutputs method. */
+  void AllocateOutputs() override;
 
   /** Initialize some accumulators before the threads run. */
-  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+  void BeforeThreadedGenerateData() override;
 
-  /** Do final mean and variance computation from data accumulated in threads.
-    */
-  void AfterThreadedGenerateData() ITK_OVERRIDE;
+  /** Do final mean and variance computation from data accumulated in threads. */
+  void AfterThreadedGenerateData() override;
 
   /** Multi-thread version GenerateData. */
-  void  DynamicThreadedGenerateData(const RegionType & outputRegionForThread) ITK_OVERRIDE;
+  void DynamicThreadedGenerateData(const RegionType & outputRegionForThread) override;
 
-  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
 

--- a/include/itkBoneMorphometryFeaturesImageFilter.h
+++ b/include/itkBoneMorphometryFeaturesImageFilter.h
@@ -69,11 +69,11 @@ public ImageToImageFilter< TInputImage, TOutputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(BoneMorphometryFeaturesImageFilter);
 
-  /** Standard Self typedef */
-  typedef BoneMorphometryFeaturesImageFilter              Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage>  Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard Self type alias. */
+  using Self = BoneMorphometryFeaturesImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -81,31 +81,31 @@ public:
   /** Runtime information support. */
   itkTypeMacro(BoneMorphometryFeaturesImageFilter, ImageToImageFilter);
 
-  /** Image related typedefs. */
-  typedef typename TInputImage::Pointer    InputImagePointer;
-  typedef typename TInputImage::RegionType RegionType;
-  typedef typename TInputImage::SizeType   SizeType;
-  typedef typename TInputImage::IndexType  IndexType;
-  typedef typename TInputImage::PixelType  PixelType;
+  /** Image related type alias. */
+  using InputImagePointer = typename TInputImage::Pointer;
+  using RegionType = typename TInputImage::RegionType;
+  using SizeType = typename TInputImage::SizeType;
+  using IndexType = typename TInputImage::IndexType;
+  using PixelType = typename TInputImage::PixelType;
 
-  /** Mask related typedefs. */
-  typedef typename TMaskImage::Pointer    MaskImagePointer;
+  /** Mask related type alias. */
+  using MaskImagePointer = typename TMaskImage::Pointer;
 
-  /** Output related typedefs. */
-  typedef typename TOutputImage::Pointer                            OutputImagePointer;
-  typedef typename TOutputImage::RegionType                         OutputRegionType;
-  typedef typename TOutputImage::PixelType                          OutputPixelType;
-  typedef typename NumericTraits< OutputPixelType >::ScalarRealType OutputRealType;
+  /** Output related type alias. */
+  using OutputImagePointer = typename TOutputImage::Pointer; 
+  using OutputRegionType = typename TOutputImage::RegionType;
+  using OutputPixelType = typename TOutputImage::PixelType;
+  using OutputRealType = typename NumericTraits< OutputPixelType >::ScalarRealType;
 
-  /** NeighborhoodIterator typedef */
-  typedef ConstantBoundaryCondition< TInputImage >                           BoundaryConditionType;
-  typedef ConstNeighborhoodIterator< TInputImage, BoundaryConditionType >    NeighborhoodIteratorType;
-  typedef typename NeighborhoodIteratorType::RadiusType                      NeighborhoodRadiusType;
-  typedef typename NeighborhoodIteratorType::OffsetType                      NeighborhoodOffsetType;
-  typedef typename NeighborhoodIteratorType::NeighborIndexType               NeighborIndexType;
+  /** NeighborhoodIterator type alias. */
+  using BoundaryConditionType = ConstantBoundaryCondition< TInputImage >;
+  using NeighborhoodIteratorType = ConstNeighborhoodIterator< TInputImage, BoundaryConditionType >;
+  using NeighborhoodRadiusType = typename NeighborhoodIteratorType::RadiusType;
+  using NeighborhoodOffsetType = typename NeighborhoodIteratorType::OffsetType;
+  using NeighborIndexType = typename NeighborhoodIteratorType::NeighborIndexType;
 
   /** Type to use for computations. */
-  typedef typename NumericTraits< PixelType >::RealType RealType;
+  using RealType = typename NumericTraits< PixelType >::RealType;
 
   /** Methods to set/get the mask image */
   itkSetInputMacro(MaskImage, TMaskImage);
@@ -131,20 +131,18 @@ public:
 
 protected:
   BoneMorphometryFeaturesImageFilter();
-  virtual ~BoneMorphometryFeaturesImageFilter() {}
+  ~BoneMorphometryFeaturesImageFilter() override {}
 
-  /** Do final mean and variance computation from data accumulated in threads.
-    */
-  virtual void GenerateOutputInformation() ITK_OVERRIDE;
+  /** Do final mean and variance computation from data accumulated in threads. */
+  void GenerateOutputInformation() override;
 
   /** Multi-thread version GenerateData. */
-  virtual void  DynamicThreadedGenerateData(const RegionType & outputRegionForThread) ITK_OVERRIDE;
+  virtual void DynamicThreadedGenerateData(const RegionType & outputRegionForThread) override;
 
   bool IsInsideNeighborhood(const NeighborhoodOffsetType &iteratedOffset);
   bool IsInsideMaskRegion(const IndexType &imageIndex, const typename TMaskImage::SizeType &maskSize);
 
-
-  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
 

--- a/include/itkBoneMorphometryFeaturesImageFilter.hxx
+++ b/include/itkBoneMorphometryFeaturesImageFilter.hxx
@@ -34,8 +34,8 @@ BoneMorphometryFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
   this->SetNumberOfRequiredInputs( 1 );
 
-  typedef Neighborhood<typename TInputImage::PixelType,
-    TInputImage::ImageDimension> NeighborhoodType;
+  using NeighborhoodType = Neighborhood<typename TInputImage::PixelType,
+    TInputImage::ImageDimension>;
   NeighborhoodType nhood;
   nhood.SetRadius( 2 );
   this->m_NeighborhoodRadius = nhood.GetRadius( );
@@ -96,7 +96,7 @@ BoneMorphometryFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
     inputNIt.SetBoundaryCondition(BoundaryCondition);
     inputNIt.GoToBegin();
 
-    typedef itk::ImageRegionIterator< TOutputImage> IteratorType;
+    using IteratorType = itk::ImageRegionIterator< TOutputImage >;
     IteratorType outputIt( outputPtr, *fit );
 
     while( !inputNIt.IsAtEnd() )

--- a/include/itkReplaceFeatureMapNanInfImageFilter.h
+++ b/include/itkReplaceFeatureMapNanInfImageFilter.h
@@ -54,11 +54,11 @@ public ImageToImageFilter< TImage, TImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(ReplaceFeatureMapNanInfImageFilter);
 
-  /** Standard Self typedef */
-  typedef ReplaceFeatureMapNanInfImageFilter    Self;
-  typedef ImageToImageFilter< TImage, TImage>   Superclass;
-  typedef SmartPointer< Self >                  Pointer;
-  typedef SmartPointer< const Self >            ConstPointer;
+  /** Standard Self type alias. */
+  using Self = ReplaceFeatureMapNanInfImageFilter;
+  using Superclass = ImageToImageFilter< TImage, TImage>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -68,30 +68,30 @@ public:
 
 protected:
 
-  /** Input Image related typedefs. */
-  typedef typename TImage::Pointer           ImagePointer;
-  typedef typename TImage::RegionType        RegionType;
-  typedef typename TImage::SizeType          SizeType;
-  typedef typename TImage::IndexType         IndexType;
-  typedef typename TImage::PixelType         PixelType;
+  /** Input Image related type alias. */
+  using ImagePointer = typename TImage::Pointer;
+  using RegionType = typename TImage::RegionType;
+  using SizeType = typename TImage::SizeType;
+  using IndexType = typename TImage::IndexType;
+  using PixelType = typename TImage::PixelType;
 
   /** Type to use for computations. */
-  typedef typename NumericTraits< PixelType >::ScalarRealType RealType;
+  using RealType = typename NumericTraits< PixelType >::ScalarRealType;
 
-  /** Intermediate Image related typedefs. */
-  typedef itk::Image< RealType, TImage::ImageDimension >        InterImageType;
-  typedef itk::ImageRegionConstIterator< InterImageType >       InterIteratorType;
+  /** Intermediate Image related type alias. */
+  using InterImageType =  itk::Image< RealType, TImage::ImageDimension >;
+  using InterIteratorType = itk::ImageRegionConstIterator< InterImageType >;
 
   ReplaceFeatureMapNanInfImageFilter();
-  virtual ~ReplaceFeatureMapNanInfImageFilter() {}
+  ~ReplaceFeatureMapNanInfImageFilter() override {}
 
-  typedef VectorIndexSelectionCastImageFilter< TImage , InterImageType > IndexSelectionFiterType;
-  typedef MinimumMaximumImageFilter< InterImageType >                    MinMaxImageFilterType;
-  typedef MaskImageFilter< InterImageType , InterImageType >             MaskImageFilterType;
+  using IndexSelectionFiterType = VectorIndexSelectionCastImageFilter< TImage , InterImageType >;
+  using MinMaxImageFilterType = MinimumMaximumImageFilter< InterImageType >;
+  using MaskImageFilterType = MaskImageFilter< InterImageType , InterImageType >;
 
-  void GenerateData() ITK_OVERRIDE;
+  void GenerateData() override;
 
-  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
   typename  IndexSelectionFiterType::Pointer   m_IndexSelectionFiter;

--- a/include/itkReplaceFeatureMapNanInfImageFilter.hxx
+++ b/include/itkReplaceFeatureMapNanInfImageFilter.hxx
@@ -69,7 +69,7 @@ ReplaceFeatureMapNanInfImageFilter<TImage>
     TImage* outputPtr = this->GetOutput();
     outputPtr->SetRegions( this->GetInput()->GetLargestPossibleRegion());
     outputPtr->Allocate();
-    typedef ImageRegionIterator< TImage > IteratorType;
+    using IteratorType = ImageRegionIterator< TImage >;
     IteratorType outputIt( outputPtr, outputPtr->GetLargestPossibleRegion() );
     outputIt.GoToBegin();
     interIt.GoToBegin();

--- a/test/BoneMorphometryFeaturesFilterInstantiationTest.cxx
+++ b/test/BoneMorphometryFeaturesFilterInstantiationTest.cxx
@@ -34,13 +34,13 @@ int BoneMorphometryFeaturesFilterInstantiationTest( int argc, char *argv[] )
     return EXIT_FAILURE;
     }
 
-  const unsigned int ImageDimension = 3;
+  constexpr unsigned int ImageDimension = 3;
 
   // Declare types
-  typedef float                                       InputPixelType;
+  using InputPixelType = float;
 
-  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  using InputImageType = itk::Image< InputPixelType, ImageDimension >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
   // Create and set up a reader
   ReaderType::Pointer reader = ReaderType::New();
@@ -51,7 +51,7 @@ int BoneMorphometryFeaturesFilterInstantiationTest( int argc, char *argv[] )
   maskReader->SetFileName( argv[2] );
 
   // Create the filter
-  typedef itk::BoneMorphometryFeaturesFilter<InputImageType> FilterType;
+  using FilterType = itk::BoneMorphometryFeaturesFilter<InputImageType>;
   FilterType::Pointer filter = FilterType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( filter,
@@ -72,7 +72,7 @@ int BoneMorphometryFeaturesFilterInstantiationTest( int argc, char *argv[] )
   TEST_EXPECT_TRUE (itk::Math::FloatAlmostEqual( 0.824595, filter->GetTbTh(),6,0.000001));
   TEST_EXPECT_TRUE (itk::Math::FloatAlmostEqual( 2.72796, filter->GetTbSp(),5,0.00001));
   TEST_EXPECT_TRUE (itk::Math::FloatAlmostEqual( 2.42543, filter->GetBSBV(),5,0.00001));
-  \
+
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/BoneMorphometryFeaturesImageFilterInstantiationTest.cxx
+++ b/test/BoneMorphometryFeaturesImageFilterInstantiationTest.cxx
@@ -36,18 +36,17 @@ int BoneMorphometryFeaturesImageFilterInstantiationTest( int argc, char *argv[] 
     return EXIT_FAILURE;
     }
 
-  const unsigned int ImageDimension = 3;
-  const unsigned int VectorComponentDimension = 5;
+  constexpr unsigned int ImageDimension = 3;
+  constexpr unsigned int VectorComponentDimension = 5;
 
   // Declare types
-  typedef float                                         InputPixelType;
-  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  using InputPixelType = float;
+  using InputImageType = itk::Image< InputPixelType, ImageDimension >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
-  typedef float                                         OutputPixelComponentType;
-  typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
-                                                        OutputPixelType;
-  typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
+  using OutputPixelComponentType  = float;
+  using OutputPixelType = itk::Vector< OutputPixelComponentType, VectorComponentDimension >;
+  using OutputImageType = itk::Image< OutputPixelType, ImageDimension >;
 
   // Create and set up a reader
   ReaderType::Pointer reader = ReaderType::New();
@@ -58,7 +57,7 @@ int BoneMorphometryFeaturesImageFilterInstantiationTest( int argc, char *argv[] 
   maskReader->SetFileName( argv[2] );
 
   // Create the filter
-  typedef itk::BoneMorphometryFeaturesImageFilter<InputImageType, OutputImageType, InputImageType> FilterType;
+  using FilterType = itk::BoneMorphometryFeaturesImageFilter<InputImageType, OutputImageType, InputImageType>;
   FilterType::Pointer filter = FilterType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( filter,
@@ -75,7 +74,7 @@ int BoneMorphometryFeaturesImageFilterInstantiationTest( int argc, char *argv[] 
   TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
   // Create and set up a writer
-  typedef itk::ImageFileWriter< OutputImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< OutputImageType >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( argv[3] );
   writer->SetInput( filter->GetOutput() );

--- a/test/ReplaceFeatureMapNanInfImageFilterInstantiationTest.cxx
+++ b/test/ReplaceFeatureMapNanInfImageFilterInstantiationTest.cxx
@@ -38,18 +38,17 @@ int ReplaceFeatureMapNanInfImageFilterInstantiationTest( int argc, char *argv[] 
     return EXIT_FAILURE;
     }
 
-  const unsigned int ImageDimension = 3;
-  const unsigned int VectorComponentDimension = 5;
+  constexpr unsigned int ImageDimension = 3;
+  constexpr unsigned int VectorComponentDimension = 5;
 
   // Declare types
-  typedef float                                         InputPixelType;
-  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  using InputPixelType = float;
+  using InputImageType = itk::Image< InputPixelType, ImageDimension >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
-  typedef float                                         OutputPixelComponentType;
-  typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
-                                                        OutputPixelType;
-  typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
+  using OutputPixelComponentType = float;
+  using OutputPixelType = itk::Vector< OutputPixelComponentType, VectorComponentDimension >;
+  using OutputImageType = itk::Image< OutputPixelType, ImageDimension >;
 
   // Create and set up a reader
   ReaderType::Pointer reader = ReaderType::New();
@@ -60,7 +59,7 @@ int ReplaceFeatureMapNanInfImageFilterInstantiationTest( int argc, char *argv[] 
   maskReader->SetFileName( argv[2] );
 
   // Create the filter
-  typedef itk::BoneMorphometryFeaturesImageFilter<InputImageType, OutputImageType, InputImageType> FilterType;
+  using FilterType = itk::BoneMorphometryFeaturesImageFilter<InputImageType, OutputImageType, InputImageType>;
   FilterType::Pointer filter = FilterType::New();
 
 
@@ -70,13 +69,13 @@ int ReplaceFeatureMapNanInfImageFilterInstantiationTest( int argc, char *argv[] 
 
   TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
-  typedef itk::ReplaceFeatureMapNanInfImageFilter<OutputImageType> PostProcessingFilterType;
+  using PostProcessingFilterType = itk::ReplaceFeatureMapNanInfImageFilter<OutputImageType>;
   PostProcessingFilterType::Pointer postProcessingFilter = PostProcessingFilterType::New();
 
   postProcessingFilter->SetInput( filter->GetOutput() );
 
   // Create and set up a writer
-  typedef itk::ImageFileWriter< OutputImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< OutputImageType >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( argv[3] );
   writer->SetInput( postProcessingFilter->GetOutput() );


### PR DESCRIPTION
Update to C++11 syntax:
- Prefer to use the standard `override` keyword to the `ITK_OVERRIDE`
macro.
- Improve override consistency:
  - virtual for the base class function declaration.
    This is technically necessary.

  - Use override (only) for a derived class' override.
    This helps with maintenance.

- Prefer C++11 type alias (`using`) over `typedef`.
- Prefer `constexpr` for constant numeric literals