### PR TITLE
ENH: Remove unnecessary call to writer's `PrintSelf`.

### DIFF
--- a/test/BoneMorphometryFeaturesImageFilterInstantiationTest.cxx
+++ b/test/BoneMorphometryFeaturesImageFilterInstantiationTest.cxx
@@ -80,10 +80,6 @@ int BoneMorphometryFeaturesImageFilterInstantiationTest( int argc, char *argv[] 
   writer->SetFileName( argv[3] );
   writer->SetInput( filter->GetOutput() );
 
-  std::cout<<"**********"<<std::endl;
-  writer->Print(std::cout);
-  std::cout<<"**********"<<std::endl;
-
   TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
   std::cout << "Test finished." << std::endl;


### PR DESCRIPTION
Remove unnecessary call to writer's `PrintSelf` method in test.