### PR TITLE
ENH: Prevent the copy and assign operations.

### DIFF
--- a/include/itkBoneMorphometryFeaturesFilter.h
+++ b/include/itkBoneMorphometryFeaturesFilter.h
@@ -58,6 +58,8 @@ class ITK_TEMPLATE_EXPORT BoneMorphometryFeaturesFilter:
 public ImageToImageFilter< TInputImage, TInputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BoneMorphometryFeaturesFilter);
+
   /** Standard Self typedef */
   typedef BoneMorphometryFeaturesFilter                   Self;
   typedef ImageToImageFilter< TInputImage, TInputImage >  Superclass;

--- a/include/itkBoneMorphometryFeaturesImageFilter.h
+++ b/include/itkBoneMorphometryFeaturesImageFilter.h
@@ -67,6 +67,8 @@ class ITK_TEMPLATE_EXPORT BoneMorphometryFeaturesImageFilter:
 public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BoneMorphometryFeaturesImageFilter);
+
   /** Standard Self typedef */
   typedef BoneMorphometryFeaturesImageFilter              Self;
   typedef ImageToImageFilter< TInputImage, TOutputImage>  Superclass;

--- a/include/itkReplaceFeatureMapNanInfImageFilter.h
+++ b/include/itkReplaceFeatureMapNanInfImageFilter.h
@@ -52,6 +52,8 @@ class ITK_TEMPLATE_EXPORT ReplaceFeatureMapNanInfImageFilter:
 public ImageToImageFilter< TImage, TImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ReplaceFeatureMapNanInfImageFilter);
+
   /** Standard Self typedef */
   typedef ReplaceFeatureMapNanInfImageFilter    Self;
   typedef ImageToImageFilter< TImage, TImage>   Superclass;


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to prevent copy and
assign operations over the classes.

Make the macro be in the public section following the discussion in:
https://discourse.itk.org/t/noncopyable