### PR TITLE
STYLE: Prefer = default to explicitly trivial implementations

### DIFF
--- a/include/itkBoneMorphometryFeaturesFilter.h
+++ b/include/itkBoneMorphometryFeaturesFilter.h
@@ -152,7 +152,7 @@ public:
 
 protected:
   BoneMorphometryFeaturesFilter();
-  ~BoneMorphometryFeaturesFilter() override {}
+  ~BoneMorphometryFeaturesFilter() override = default;
 
 
   /** Pass the input through unmodified. Do this by Grafting in the

--- a/include/itkBoneMorphometryFeaturesImageFilter.h
+++ b/include/itkBoneMorphometryFeaturesImageFilter.h
@@ -131,7 +131,7 @@ public:
 
 protected:
   BoneMorphometryFeaturesImageFilter();
-  ~BoneMorphometryFeaturesImageFilter() override {}
+  ~BoneMorphometryFeaturesImageFilter() override = default;
 
   /** Do final mean and variance computation from data accumulated in threads. */
   void GenerateOutputInformation() override;

--- a/include/itkReplaceFeatureMapNanInfImageFilter.h
+++ b/include/itkReplaceFeatureMapNanInfImageFilter.h
@@ -83,7 +83,7 @@ protected:
   using InterIteratorType = itk::ImageRegionConstIterator< InterImageType >;
 
   ReplaceFeatureMapNanInfImageFilter();
-  ~ReplaceFeatureMapNanInfImageFilter() override {}
+  ~ReplaceFeatureMapNanInfImageFilter() override  = default;
 
   using IndexSelectionFiterType = VectorIndexSelectionCastImageFilter< TImage , InterImageType >;
   using MinMaxImageFilterType = MinimumMaximumImageFilter< InterImageType >;


### PR DESCRIPTION
This check replaces default bodies of special member functions with
`= default;`. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of `= default` more clearly expresses the
intent for the special member functions.