### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkBoneMorphometryFeaturesFilter.h
+++ b/include/itkBoneMorphometryFeaturesFilter.h
@@ -57,7 +57,7 @@ template <typename TInputImage, typename TMaskImage = Image<unsigned char, TInpu
 class ITK_TEMPLATE_EXPORT BoneMorphometryFeaturesFilter : public ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BoneMorphometryFeaturesFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BoneMorphometryFeaturesFilter);
 
   /** Standard Self type alias. */
   using Self = BoneMorphometryFeaturesFilter;

--- a/include/itkBoneMorphometryFeaturesImageFilter.h
+++ b/include/itkBoneMorphometryFeaturesImageFilter.h
@@ -66,7 +66,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT BoneMorphometryFeaturesImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BoneMorphometryFeaturesImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BoneMorphometryFeaturesImageFilter);
 
   /** Standard Self type alias. */
   using Self = BoneMorphometryFeaturesImageFilter;

--- a/include/itkReplaceFeatureMapNanInfImageFilter.h
+++ b/include/itkReplaceFeatureMapNanInfImageFilter.h
@@ -51,7 +51,7 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT ReplaceFeatureMapNanInfImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ReplaceFeatureMapNanInfImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ReplaceFeatureMapNanInfImageFilter);
 
   /** Standard Self type alias. */
   using Self = ReplaceFeatureMapNanInfImageFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.