### PR TITLE
Fix Error in BsBv formula

### DIFF
--- a/doc/itkBoneMorphometry.tex
+++ b/doc/itkBoneMorphometry.tex
@@ -148,7 +148,7 @@ TbN_{x/y/z} = \frac{N_{Boundary x/y/z}}{N_{Total}*ImSpacing_{x/y/z}}
 
 \textbf{Bone surface density} or BsBv (which stands for  stands for Bone Surface Bs over Bone Volume Bv) gives an indication on how many bone lining cells cover a given volume of bone (Bv).
 \begin{equation} \label{eqn:BsBv}
-BsBv = 2 \frac{TbN}{BsBv}
+BsBv = 2 \frac{TbN}{BvTv}
 \end{equation}
 
 \textbf{Trabecular thickness} (TbTh) is determined by filling maximal spheres into the structure using a distance transform. Then the average thickness of all maximal spheres is calculated to give an estimate of mean TbTh.


### PR DESCRIPTION
According to lines:
https://github.com/InsightSoftwareConsortium/ITKBoneMorphometry/blob/b9a1292e1b3413f25fef01a07b7e16661d61ca3d/include/itkBoneMorphometryFeaturesFilter.h#L159
https://github.com/InsightSoftwareConsortium/ITKBoneMorphometry/blob/b9a1292e1b3413f25fef01a07b7e16661d61ca3d/include/itkBoneMorphometryFeaturesFilter.h#L120
https://github.com/InsightSoftwareConsortium/ITKBoneMorphometry/blob/b9a1292e1b3413f25fef01a07b7e16661d61ca3d/include/itkBoneMorphometryFeaturesFilter.h#L107

From the code the formula stated in the paper does not agree.  The formula in the paper doesn't agree with the literature as well.  Essentially there is a small error in the formula within the text that could be confusing for users trying to understand the parameters generated.

Thanks for contributing this code!