### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkBoneMorphometryFeaturesFilter.hxx
+++ b/include/itkBoneMorphometryFeaturesFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBoneMorphometryFeaturesFilter_hxx
 #define itkBoneMorphometryFeaturesFilter_hxx
 
-#include "itkBoneMorphometryFeaturesFilter.h"
 
 #include "itkImageScanlineIterator.h"
 #include "itkProgressReporter.h"

--- a/include/itkBoneMorphometryFeaturesImageFilter.hxx
+++ b/include/itkBoneMorphometryFeaturesImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBoneMorphometryFeaturesImageFilter_hxx
 #define itkBoneMorphometryFeaturesImageFilter_hxx
 
-#include "itkBoneMorphometryFeaturesImageFilter.h"
 
 #include "itkImageScanlineIterator.h"
 #include "itkProgressReporter.h"
@@ -210,7 +209,7 @@ BoneMorphometryFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>::IsIns
   bool insideNeighborhood = true;
   for (unsigned int i = 0; i < this->m_NeighborhoodRadius.Dimension; ++i)
   {
-    int boundDistance = m_NeighborhoodRadius[i] - Math::abs(iteratedOffset[i]);
+    int boundDistance = m_NeighborhoodRadius[i] - itk::Math::abs(iteratedOffset[i]);
     if (boundDistance < 0)
     {
       insideNeighborhood = false;

--- a/include/itkReplaceFeatureMapNanInfImageFilter.hxx
+++ b/include/itkReplaceFeatureMapNanInfImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkReplaceFeatureMapNanInfImageFilter_hxx
 #define itkReplaceFeatureMapNanInfImageFilter_hxx
 
-#include "itkReplaceFeatureMapNanInfImageFilter.h"
 
 namespace itk
 {


### PR DESCRIPTION
The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).